### PR TITLE
add download only for pre-fetch of runtimes

### DIFF
--- a/dronekit_sitl/__init__.py
+++ b/dronekit_sitl/__init__.py
@@ -107,18 +107,30 @@ def download(system, version, target, verbose=False):
         if not os.path.isdir(sitl_target):
             os.makedirs(sitl_target)
 
-        testfile = URLopener()
-        testfile.retrieve(sitl_file, sitl_target + '/sitl.tar.gz')
+        def check_complete(count, block_size, total_size):
+            if verbose and total_size != -1 and (count * block_size) >= total_size:
+                print('Download Complete.')
 
+        try:
+            testfile = URLopener()
+            testfile.retrieve(sitl_file, sitl_target + '/sitl.tar.gz', check_complete)
+        except IOError as ioe:
+            if ioe.args[1] == 404:
+                print('File Not Found: %s' % sitl_file)
+                sys.exit(1)
+
+        # TODO: cleanup sitl.tar.gz
         tar = tarfile.open(sitl_target + '/sitl.tar.gz')
         tar.extractall(path=sitl_target + '/' + system + '-' + version)
         tar.close()
 
         if verbose:
-            print('Extracted.')
+            print("Payload Extracted.")
     else:
         if verbose:
-            print("SITL already Downloaded.")
+            print("SITL already Downloaded and Extracted.")
+    if verbose:
+        print('Ready to boot.')
 
 class SITL():
     def __init__(self, path=None):
@@ -374,10 +386,20 @@ def main(args=None):
         print('--local no longer needed. Specify an absolute or relative file path.')
         sys.exit(1)
 
+    if len(args) > 0 and args[0] == 'download':
+        capture = re.match(r'([a-z]*)(\-)(([0-9]{1,}|(\.))*)', args[1])
+        system = capture.group(1)
+        version = capture.group(3)
+        print('os: %s, apm: %s, release: %s' % (target, system, version))
+        sitl = SITL()
+        sitl.download(system, version, target=target, verbose=True)
+        sys.exit(1)
+
     if len(args) < 1 or not re.match(r'^(copter|plane|solo|rover)(-v?.+)?|^[./]|:', args[0]) and not local:
         print('Please specify one of:', file=sys.stderr)
         print('  dronekit-sitl --list', file=sys.stderr)
         print('  dronekit-sitl --reset', file=sys.stderr)
+        print('  dronekit-sitl download <(copter|plane|rover|solo)(-version)>', file=sys.stderr)
         print('  dronekit-sitl <copter(-version)> [args...]', file=sys.stderr)
         print('  dronekit-sitl <plane(-version)> [args...]', file=sys.stderr)
         print('  dronekit-sitl <rover(-version)> [args...]', file=sys.stderr)

--- a/dronekit_sitl/__init__.py
+++ b/dronekit_sitl/__init__.py
@@ -12,6 +12,7 @@ import json
 import tarfile
 import sys
 from six.moves.urllib.request import URLopener, Request, urlopen
+from six.moves.urllib.error import HTTPError
 import os
 import json
 import shutil
@@ -114,8 +115,12 @@ def download(system, version, target, verbose=False):
         try:
             testfile = URLopener()
             testfile.retrieve(sitl_file, sitl_target + '/sitl.tar.gz', check_complete)
-        except IOError as ioe:
-            if ioe.args[1] == 404:
+        except HTTPError as e:
+            if e.code == 404:
+                print('File Not Found: %s' % sitl_file)
+                sys.exit(1)
+        except IOError as e:
+            if e.args[1] == 404:
                 print('File Not Found: %s' % sitl_file)
                 sys.exit(1)
 

--- a/tests/test_download_cmd.py
+++ b/tests/test_download_cmd.py
@@ -1,0 +1,9 @@
+from dronekit_sitl import SITL
+from nose.tools import raises
+import unittest
+
+class TestDownloader(unittest.TestCase):
+    @raises(SystemExit)
+    def test_download_404(self):
+        sitl = SITL()
+        sitl.download('rocket', '1.123.098.123')

--- a/tests/test_sitl.py
+++ b/tests/test_sitl.py
@@ -8,7 +8,7 @@ def test_sitl():
     sitl.download('copter', '3.3')
     sitl.launch(copter_args)
     sitl.block_until_ready()
-    
+
     assert_equals(sitl.poll(), None, 'SITL should still be running.')
     assert_equals(sitl.using_sim, False, 'SITL for copter-3.3 should not be using pysim')
 


### PR DESCRIPTION
example: dronekit-sitl download copter-3.3

Some level of error handling was introduced to the download block which now checks for a 404 http-status.

I also introduced some re-wording throughout the download process, which includes a download complete check (assuming the total size of the file is known and reported by server).