### PR TITLE
Pass the `--gimbal` option through to legacy SITL

### DIFF
--- a/dronekit_sitl/__init__.py
+++ b/dronekit_sitl/__init__.py
@@ -207,6 +207,7 @@ class SITL():
             parser.add_argument('--rate')
             parser.add_argument('--model')
             parser.add_argument('-C', action='store_true')
+            parser.add_argument('--gimbal', action='store_true')
             def noop(*args, **kwargs):
                 pass
 
@@ -233,6 +234,10 @@ class SITL():
                 simargs = [sys.executable, os.path.join(os.path.dirname(__file__), 'pysim/sim_wrapper.py'),
                            '--simin=127.0.0.1:5502', '--simout=127.0.0.1:5501', '--fgout=127.0.0.1:5503',
                            '--home='+res.home, '--frame='+res.model]
+
+                if res.gimbal:
+                    simargs.append('--gimbal')
+
                 psim = Popen(simargs, cwd=wd, shell=sys.platform == 'win32')
 
                 def cleanup_sim():

--- a/stage/build.sh
+++ b/stage/build.sh
@@ -82,7 +82,7 @@ cd ardupilot/$TARGET_ARDU
 buildit () {
   make clean BUILDROOT=$STAGING || true
   make configure SKETCHBOOK=$(pwd)/.. BUILDROOT=$STAGING || true
-  make sitl SKETCHBOOK=$(pwd)/.. BUILDROOT=$STAGING -j64 $MAKEARGS
+  make sitl-mount SKETCHBOOK=$(pwd)/.. BUILDROOT=$STAGING -j64 $MAKEARGS
 }
 
 # Thrice is nice. Works around build bugs in ArduCopter 3.2.x


### PR DESCRIPTION
* requires that apm is built with the make sitl-mount target